### PR TITLE
Allow working on LMeter on Linux

### DIFF
--- a/LMeter/LMeter.csproj
+++ b/LMeter/LMeter.csproj
@@ -39,7 +39,16 @@
     <PropertyGroup>
         <DalamudVersion>dev</DalamudVersion>
         <DalamudLocal>../dalamud/</DalamudLocal>
+    </PropertyGroup>
+    
+    <!-- Dalamud Configuration (Windows-specific) -->
+    <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
         <DalamudXIVLauncher>$(APPDATA)\XIVLauncher\addon\Hooks\$(DalamudVersion)</DalamudXIVLauncher>
+    </PropertyGroup>
+    
+    <!-- Dalamud Configuration (Linux-specific) -->
+    <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Linux'))">
+        <DalamudXIVLauncher>$(HOME)/.xlcore/dalamud/Hooks/$(DalamudVersion)</DalamudXIVLauncher>
     </PropertyGroup>
 
     <!-- Assembly Reference Locations -->


### PR DESCRIPTION
This is just a compatibility change to allow working on the plugin while on Linux. I am actually pretty surprised that this isn't a more general thing, though I guess most XL users ARE on Windows.

Oh, this PR is from the original repo by the way, maybe it will get merged here c: