### PR TITLE
Update to dalamud v9

### DIFF
--- a/LMeter/LMeter.csproj
+++ b/LMeter/LMeter.csproj
@@ -161,7 +161,7 @@
     <!-- NuGet Packages -->
     <ItemGroup>
         <PackageReference Include="AngleSharp" Version="1.0.1" />
-        <PackageReference Include="DalamudPackager" Version="2.1.11" />
+        <PackageReference Include="DalamudPackager" Version="2.1.12" />
     </ItemGroup>
 
     <!-- Dalamud Packager Task-->

--- a/LMeter/LMeter.json
+++ b/LMeter/LMeter.json
@@ -1,5 +1,6 @@
 {
     "Name": "LMeter",
+    "InternalName": "lmeter",
     "Author": "Lichie, joshua.software.dev",
     "Punchline": "Plugin to display ACT combat log data.",
     "Description": "Renders ACT combat log data (and optionally Cactbot) as a plugin instead of using a web based overlay",

--- a/LMeter/src/Act/ActClient.cs
+++ b/LMeter/src/Act/ActClient.cs
@@ -1,5 +1,6 @@
 using Dalamud.Game.Gui;
 using Dalamud.Plugin;
+using Dalamud.Plugin.Services;
 using LMeter.Config;
 
 
@@ -8,12 +9,12 @@ namespace LMeter.Act;
 public class ActClient
 {
     private readonly ActConfig _config;
-    private readonly ChatGui _chatGui;
+    private readonly IChatGui _chatGui;
     private readonly DalamudPluginInterface _dpi;
 
     public IActClient Current;
 
-    public ActClient(ChatGui chatGui, ActConfig config, DalamudPluginInterface dpi)
+    public ActClient(IChatGui chatGui, ActConfig config, DalamudPluginInterface dpi)
     {
         _chatGui = chatGui;
         _config = config;

--- a/LMeter/src/Act/ActWebSocketClient.cs
+++ b/LMeter/src/Act/ActWebSocketClient.cs
@@ -13,6 +13,7 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Threading;
 using System;
+using Dalamud.Plugin.Services;
 
 
 namespace LMeter.Act;
@@ -35,14 +36,14 @@ public class ActWebSocketClient : ActEventParser, IActClient
     private ClientWebSocket _socket;
     private CancellationTokenSource _cancellationTokenSource;
     private Task? _receiveTask;
-    private readonly ChatGui _chatGui;
+    private readonly IChatGui _chatGui;
 
     private ConnectionStatus _status;
     private string? _lastErrorMessage;
 
     public const string SubscriptionMessage = """{"call":"subscribe","events":["CombatData"]}""";
 
-    public ActWebSocketClient(ChatGui chatGui, ActConfig config)
+    public ActWebSocketClient(IChatGui chatGui, ActConfig config)
     {
         _chatGui = chatGui;
         _config = config;
@@ -202,7 +203,7 @@ public class ActWebSocketClient : ActEventParser, IActClient
             Type = XivChatType.Echo
         };
 
-        _chatGui.PrintChat(message);
+        _chatGui.Print(message);
     }
 
     public void Clear()
@@ -217,7 +218,7 @@ public class ActWebSocketClient : ActEventParser, IActClient
                 Type = XivChatType.Echo
             };
 
-            _chatGui.PrintChat(message);
+            _chatGui.Print(message);
         }
     }
 

--- a/LMeter/src/Act/IinactClient.cs
+++ b/LMeter/src/Act/IinactClient.cs
@@ -10,6 +10,7 @@ using LMeter.Config;
 using Newtonsoft.Json.Linq;
 using System.Collections.Generic;
 using System;
+using Dalamud.Plugin.Services;
 
 
 namespace LMeter.Act;
@@ -28,7 +29,7 @@ public enum SubscriptionStatus
 
 public class IinactClient : ActEventParser, IActClient
 {
-    private readonly ChatGui _chatGui;
+    private readonly IChatGui _chatGui;
     private readonly ActConfig _config;
     private readonly DalamudPluginInterface _dpi;
     private readonly ICallGateProvider<JObject, bool> subscriptionReceiver;
@@ -44,7 +45,7 @@ public class IinactClient : ActEventParser, IActClient
     private SubscriptionStatus _status;
     private string? _lastErrorMessage;
 
-    public IinactClient(ChatGui chatGui, ActConfig config, DalamudPluginInterface dpi)
+    public IinactClient(IChatGui chatGui, ActConfig config, DalamudPluginInterface dpi)
     {
         _chatGui = chatGui;
         _config = config;
@@ -206,7 +207,7 @@ public class IinactClient : ActEventParser, IActClient
             Type = XivChatType.Echo
         };
 
-        _chatGui.PrintChat(message);
+        _chatGui.Print(message);
     }
 
     public void Clear()
@@ -222,7 +223,7 @@ public class IinactClient : ActEventParser, IActClient
                 Type = XivChatType.Echo
             };
 
-            _chatGui.PrintChat(message);
+            _chatGui.Print(message);
         }
     }
 

--- a/LMeter/src/Cactbot/CactbotState.cs
+++ b/LMeter/src/Cactbot/CactbotState.cs
@@ -48,7 +48,7 @@ public class CactbotState
             Message = $"RAIDBOSS ALARM: {Alarm}",
             Type = XivChatType.ErrorMessage
         };
-        PluginManager.Instance.ChatGui.PrintChat(message);
+        PluginManager.Instance.ChatGui.Print(message);
     }
 
     private void OnAlertStateChange(object? sender, EventArgs eventArgs)
@@ -61,7 +61,7 @@ public class CactbotState
             Name = "RAIDBOSS ALERT",
             Type = XivChatType.Yell
         };
-        PluginManager.Instance.ChatGui.PrintChat(message);
+        PluginManager.Instance.ChatGui.Print(message);
     }
 
     private void OnInfoStateChange(object? sender, EventArgs eventArgs)
@@ -74,7 +74,7 @@ public class CactbotState
             Name = "RAIDBOSS INFO",
             Type = XivChatType.NPCDialogueAnnouncements
         };
-        PluginManager.Instance.ChatGui.PrintChat(message);
+        PluginManager.Instance.ChatGui.Print(message);
     }
 
     private void UpdateTimeline(IHtmlDocument html)

--- a/LMeter/src/Cactbot/IinactCactbotClient.cs
+++ b/LMeter/src/Cactbot/IinactCactbotClient.cs
@@ -13,6 +13,7 @@ using System.Net.Sockets;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Dalamud.Plugin.Services;
 
 
 namespace LMeter.Cactbot;
@@ -20,7 +21,7 @@ namespace LMeter.Cactbot;
 public class IinactCactbotClient : IActClient
 {
     private readonly bool _bypassWebSocket;
-    private readonly ClientState _clientState;
+    private readonly IClientState _clientState;
     private readonly CancellationTokenSource _cancelTokenSource;
     private readonly DalamudPluginInterface _dpi;
     private readonly HttpClient _httpClient;
@@ -68,7 +69,7 @@ public class IinactCactbotClient : IActClient
     public IinactCactbotClient
     (
         bool bypassWebSocket,
-        ClientState clientState,
+        IClientState clientState,
         CancellationTokenSource cts,
         DalamudPluginInterface dpi,
         HttpClient httpClient,
@@ -93,7 +94,7 @@ public class IinactCactbotClient : IActClient
         catch { }
     }
 
-    private void HandleOnLogin(object? sender, EventArgs args)
+    private void HandleOnLogin()
     {
         if (_bypassWebSocket && !_fakeHandshakeComplete)
         {

--- a/LMeter/src/Helpers/CharacterState.cs
+++ b/LMeter/src/Helpers/CharacterState.cs
@@ -59,7 +59,7 @@ public static class CharacterState
 
         unsafe
         {
-            return (Job) ((Character*) player.Address)->ClassJob;
+            return (Job)((Character*)player.Address)->CharacterData.ClassJob;
         }
     }
 

--- a/LMeter/src/Helpers/DrawHelpers.cs
+++ b/LMeter/src/Helpers/DrawHelpers.cs
@@ -4,6 +4,7 @@ using ImGuiNET;
 using ImGuiScene;
 using System.Numerics;
 using System;
+using Dalamud.Interface.Internal;
 
 
 namespace LMeter.Helpers;
@@ -112,7 +113,7 @@ public class DrawHelpers
         drawList.AddImage(tex.ImGuiHandle, position, position + size, uv0, uv1);
     }
 
-    public static (Vector2, Vector2) GetTexCoordinates(TextureWrap? texture, bool cropIcon = true)
+    public static (Vector2, Vector2) GetTexCoordinates(IDalamudTextureWrap? texture, bool cropIcon = true)
     {
         if (texture == null) return (Vector2.Zero, Vector2.Zero);
 

--- a/LMeter/src/Helpers/TexturesCache.cs
+++ b/LMeter/src/Helpers/TexturesCache.cs
@@ -12,6 +12,8 @@ using System.IO;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System;
+using Dalamud.Interface.Internal;
+using Dalamud.Plugin.Services;
 using static Lumina.Data.Files.TexFile;
 
 
@@ -19,19 +21,19 @@ namespace LMeter.Helpers;
 
 public class TexturesCache : IDisposable
 {
-    private readonly Dictionary<string, Tuple<TextureWrap, float>> _textureCache = new ();
+    private readonly Dictionary<string, Tuple<IDalamudTextureWrap, float>> _textureCache = new ();
     private readonly ICallGateSubscriber<string, string> _penumbraPathResolver;
-    private readonly DataManager _dataManager;
+    private readonly IDataManager _dataManager;
     private readonly UiBuilder _uiBuilder;
 
-    public TexturesCache(DataManager dataManager, DalamudPluginInterface pluginInterface)
+    public TexturesCache(IDataManager dataManager, DalamudPluginInterface pluginInterface)
     {
         _penumbraPathResolver = pluginInterface.GetIpcSubscriber<string, string>("Penumbra.ResolveDefaultPath");
         _dataManager = dataManager;
         _uiBuilder = pluginInterface.UiBuilder;
     }
 
-    public TextureWrap? GetTextureFromIconId
+    public IDalamudTextureWrap? GetTextureFromIconId
     (
         uint iconId,
         uint stackCount = 0,
@@ -52,11 +54,11 @@ public class TexturesCache : IDisposable
         var newTexture = this.LoadTexture(iconId + stackCount, hdIcon, greyScale, opacity);
         if (newTexture == null) return null;
 
-        _textureCache.Add(key, new Tuple<TextureWrap, float>(newTexture, opacity));
+        _textureCache.Add(key, new Tuple<IDalamudTextureWrap, float>(newTexture, opacity));
         return newTexture;
     }
 
-    private TextureWrap? LoadTexture(uint id, bool hdIcon, bool greyScale, float opacity = 1f)
+    private IDalamudTextureWrap? LoadTexture(uint id, bool hdIcon, bool greyScale, float opacity = 1f)
     {
         var path = $"ui/icon/{id / 1000 * 1000:000000}/{id:000000}{(hdIcon ? "_hr1" : string.Empty)}.tex";
 
@@ -89,7 +91,7 @@ public class TexturesCache : IDisposable
         return null;
     }
 
-    private TextureWrap? LoadPenumbraTexture(string path)
+    private IDalamudTextureWrap? LoadPenumbraTexture(string path)
     {            
         try
         {
@@ -247,7 +249,7 @@ public class TexturesCache : IDisposable
         }
     }
 
-    private TextureWrap GetTextureWrap(TexFile tex, bool greyScale, float opacity)
+    private IDalamudTextureWrap GetTextureWrap(TexFile tex, bool greyScale, float opacity)
     {
         var bytes = tex.GetRgbaImageData();
 

--- a/LMeter/src/Helpers/Utils.cs
+++ b/LMeter/src/Helpers/Utils.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Numerics;
 using System.Runtime.InteropServices;
 using System;
+using Dalamud.Plugin.Services;
 
 
 namespace LMeter.Helpers;
@@ -26,7 +27,7 @@ public static class Utils
             _ => position
         };
 
-    public static GameObject? FindTargetOfTarget(ObjectTable objectTable, GameObject? player, GameObject? target)
+    public static GameObject? FindTargetOfTarget(IObjectTable objectTable, GameObject? player, GameObject? target)
     {
         if (target == null) return null;
 

--- a/LMeter/src/Plugin.cs
+++ b/LMeter/src/Plugin.cs
@@ -14,6 +14,8 @@ using LMeter.Meter;
 using System.IO;
 using System.Reflection;
 using System;
+using Dalamud.Interface.Internal;
+using Dalamud.Plugin.Services;
 
 
 namespace LMeter;
@@ -26,17 +28,17 @@ public class Plugin : IDalamudPlugin
     public const string ConfigFileName = "LMeter.json";
     public static string ConfigFilePath { get; private set; } = string.Empty;
     public static string? GitHash { get; private set; }
-    public static TextureWrap? IconTexture { get; private set; }
+    public static IDalamudTextureWrap? IconTexture { get; private set; }
     public string Name => "LMeter";
     public static string? Version { get; private set; }
 
     public Plugin(
-        ClientState clientState,
-        CommandManager commandManager,
-        Condition condition,
+        IClientState clientState,
+        ICommandManager commandManager,
+        ICondition condition,
         DalamudPluginInterface pluginInterface,
-        DataManager dataManager,
-        ChatGui chatGui
+        IDataManager dataManager,
+        IChatGui chatGui
     )
     {
         LoadVersion();
@@ -88,7 +90,7 @@ public class Plugin : IDalamudPlugin
         config.FirstLoad = false;
     }
 
-    private static TextureWrap? LoadIconTexture(UiBuilder uiBuilder)
+    private static IDalamudTextureWrap? LoadIconTexture(UiBuilder uiBuilder)
     {
         var pluginPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
         if (string.IsNullOrEmpty(pluginPath)) return null;

--- a/LMeter/src/PluginManager.cs
+++ b/LMeter/src/PluginManager.cs
@@ -1,11 +1,10 @@
-using Dalamud.Data;
-using Dalamud.Game.ClientState.Conditions;
-using Dalamud.Game.ClientState;
+using System;
+using System.Numerics;
 using Dalamud.Game.Command;
-using Dalamud.Game.Gui;
+using Dalamud.Interface.Utility;
 using Dalamud.Interface.Windowing;
-using Dalamud.Interface;
 using Dalamud.Plugin;
+using Dalamud.Plugin.Services;
 using ImGuiNET;
 using LMeter.Act;
 using LMeter.Cactbot;
@@ -13,18 +12,16 @@ using LMeter.Config;
 using LMeter.Helpers;
 using LMeter.Meter;
 using LMeter.Windows;
-using System.Numerics;
-using System;
-
 
 namespace LMeter;
 
 public class PluginManager : IDisposable
 {
     private readonly Vector2 _origin = ImGui.GetMainViewport().Size / 2f;
-    private readonly Vector2 _configSize = new (550, 550);
+    private readonly Vector2 _configSize = new(550, 550);
     private readonly ConfigWindow _configRoot;
     private readonly WindowSystem _windowSystem;
+
     private readonly ImGuiWindowFlags _mainWindowFlags =
         ImGuiWindowFlags.NoTitleBar |
         ImGuiWindowFlags.NoScrollbar |
@@ -34,15 +31,15 @@ public class PluginManager : IDisposable
         ImGuiWindowFlags.NoBringToFrontOnFocus |
         ImGuiWindowFlags.NoSavedSettings;
 
-    private readonly CommandManager _commandManager;
+    private readonly ICommandManager _commandManager;
     private readonly LMeterConfig _config;
 
     public readonly ActClient ActClient;
     public readonly CactbotConfig CactbotConfig;
-    public readonly ChatGui ChatGui;
-    public readonly ClientState ClientState;
-    public readonly Condition Condition;
-    public readonly DataManager DataManager;
+    public readonly IChatGui ChatGui;
+    public readonly IClientState ClientState;
+    public readonly ICondition Condition;
+    public readonly IDataManager DataManager;
     public readonly FontsManager FontsManager;
     public readonly DalamudPluginInterface PluginInterface;
     public readonly TexturesCache TexCache;
@@ -52,18 +49,18 @@ public class PluginManager : IDisposable
     public PluginManager
     (
         ActClient actClient,
-        ChatGui chatGui,
-        ClientState clientState,
-        CommandManager commandManager,
-        Condition condition,
+        IChatGui chatGui,
+        IClientState clientState,
+        ICommandManager commandManager,
+        ICondition condition,
         LMeterConfig config,
-        DataManager dataManager,
+        IDataManager dataManager,
         FontsManager fontsManager,
         DalamudPluginInterface pluginInterface,
         TexturesCache texCache
     )
     {
-        PluginManager.Instance = this;
+        Instance = this;
 
         ActClient = actClient;
         ChatGui = chatGui;
@@ -154,12 +151,12 @@ public class PluginManager : IDisposable
         if (!_configRoot.IsOpen) _configRoot.PushConfig(_config);
     }
 
-    private void OnLogin(object? sender, EventArgs? args)
+    private void OnLogin()
     {
         if (_config.ActConfig.WaitForCharacterLogin) ActClient.Current.Start();
     }
 
-    private void OnLogout(object? sender, EventArgs? args) =>
+    private void OnLogout() =>
         ConfigHelpers.SaveConfig(_config);
 
     private void PluginCommand(string command, string arguments)


### PR DESCRIPTION
Loads and appears to be working fine on patch 6.5. Haven't tested thoroughly, but I'll leave a comment (+ fix if I can) if I find anything that broke.

* Dalamud services are now accessed through their interface variants (`Service` -> `IService`)
* Some method signatures have changed
* An internal name, which I chose `lmeter` for, is now required

`PluginLog` is now deprecated, but I've left uses (that now generate warnings) untouched. It will probably be removed in v10.